### PR TITLE
fix: clean up resizable editor lifecycle

### DIFF
--- a/.src.json
+++ b/.src.json
@@ -119,6 +119,10 @@
     "AHO": {
       "name": "dist.js",
       "url": "//meta-q.cdn.bubble.io/f1786967618467x217669016491782940/dist.js"
+    },
+    "AHP": {
+      "name": "dist-issue-25-074b78ae9313.js",
+      "url": "//meta-q.cdn.bubble.io/f1788984698987x468409416958701630/dist-issue-25-074b78ae9313.js"
     }
   },
   "dependencies": {
@@ -3038,7 +3042,7 @@
       },
       "has_reset_fn": false,
       "headers": {
-        "snippet": "<script src=\"//meta-q.cdn.bubble.io/f1786967618467x217669016491782940/dist.js\" defer></script>\n\n<script\n    src=\"https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js\"\n    integrity=\"sha256-qXBd/EfAdjOA2FGrGAG+b3YBn2tn5A6bhz+LSgYD96k=\"\n    crossorigin=\"anonymous\"\n    defer\n></script>\n\n<!-- Tippy styles -->\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/light-border.min.css\"\n    integrity=\"sha512-DiG+GczLaoJczcpFjhVy4sWA1rheh0I6zmlEc+ax7vrq2y/qTg80RtxDOueLcwBrC80IsiQapIgTi++lcGHPLg==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/light.min.css\"\n    integrity=\"sha512-zpbTFOStBclqD3+SaV5Uz1WAKh9d2/vOtaFYpSLkosymyJKnO+M4vu2CK2U4ZjkRCJ7+RvLnISpNrCfJki5JXA==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/material.min.css\"\n    integrity=\"sha512-R8oUfFYCO11afzYKUhovrP+cajy9JF0iRRHbuk16gPYstVj9McxsE/D8wnH2l0aBKuhnkAd6VMLiTFV1Bp+zKA==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/translucent.min.css\"\n    integrity=\"sha512-MkXwkRGjkxAMeA0Kma3nhRs2CxojMPMv5kgP+y9OcIQkXOTPGyxmjPPddHPov59evYXjcC5B5hM4yUQ5n49Yog==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n"
+        "snippet": "<script src=\"//meta-q.cdn.bubble.io/f1788984698987x468409416958701630/dist-issue-25-074b78ae9313.js\" defer></script>\n\n<script\n    src=\"https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js\"\n    integrity=\"sha256-qXBd/EfAdjOA2FGrGAG+b3YBn2tn5A6bhz+LSgYD96k=\"\n    crossorigin=\"anonymous\"\n    defer\n></script>\n\n<!-- Tippy styles -->\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/light-border.min.css\"\n    integrity=\"sha512-DiG+GczLaoJczcpFjhVy4sWA1rheh0I6zmlEc+ax7vrq2y/qTg80RtxDOueLcwBrC80IsiQapIgTi++lcGHPLg==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/light.min.css\"\n    integrity=\"sha512-zpbTFOStBclqD3+SaV5Uz1WAKh9d2/vOtaFYpSLkosymyJKnO+M4vu2CK2U4ZjkRCJ7+RvLnISpNrCfJki5JXA==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/material.min.css\"\n    integrity=\"sha512-R8oUfFYCO11afzYKUhovrP+cajy9JF0iRRHbuk16gPYstVj9McxsE/D8wnH2l0aBKuhnkAd6VMLiTFV1Bp+zKA==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n<link\n    rel=\"stylesheet\"\n    href=\"https://cdnjs.cloudflare.com/ajax/libs/tippy.js/6.3.7/themes/translucent.min.css\"\n    integrity=\"sha512-MkXwkRGjkxAMeA0Kma3nhRs2CxojMPMv5kgP+y9OcIQkXOTPGyxmjPPddHPov59evYXjcC5B5hM4yUQ5n49Yog==\"\n    crossorigin=\"anonymous\"\n    referrerpolicy=\"no-referrer\"\n/>\n"
       },
       "icon": "ion-chatbox-working",
       "property_applications": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ Plugin-specific facts:
 - Two code piles: `src/` — decoded Bubble plugin source (Pled uploads this); `lib/` — bundled Tiptap runtime and lifecycle tests.
 - From `lib/`: `npm ci && npm test` — builds `lib/dist.js`, then runs lifecycle tests.
 - When runtime dependencies or `lib/index.js` change, release the rebuilt bundle: unique versioned filename, `pled upload`, update `src/elements/tiptap-AAC/headers.html` to the new CDN URL, then `pled push`.
-- Dev app: `tiptap-plugin`. Changes in the plugin auto-reload page code.
+- Dev app: `tiptap-plugin` uses the plugin development version (Testing). Plugin changes immediately update this app; refresh the app/editor when needed to expose new fields.
 - Run-mode login (not a real secret): **tippy** / **tappy**
 - Demo page: `tiptap-demo` — one page, each demo is a reusable — `https://tippy:tappy@tiptap-plugin.bubbleapps.io/version-test/tiptap-demo`
-- The demo page uses the plugin version published in the Bubble marketplace. It shows off the plugin in simple user-facing language, assuming a medior Bubble developer.
+- The demo page uses that development plugin version. It shows off the plugin in simple user-facing language, assuming a medior Bubble developer.
 - In every Bubble editor element, always set **File uploads enabled** to an explicit option (`yes` or `no`); never leave it empty.

--- a/lib/package.json
+++ b/lib/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "scripts": {
         "build": "esbuild index.js --bundle --minify --outfile=dist.js",
-        "test": "npm run build && node tests/ai-editor-context-lifecycle.mjs && node tests/text-style-lineheight-backgroundcolor.mjs && node tests/undo-redo-history-guard.mjs && node tests/webhook-html-node18-compatibility.mjs && node tests/image-alignment-action.mjs && node tests/table-of-contents-content-switch.mjs && node tests/table-of-contents-visual-lifecycle.mjs"
+        "test": "npm run build && node tests/ai-editor-context-lifecycle.mjs && node tests/text-style-lineheight-backgroundcolor.mjs && node tests/undo-redo-history-guard.mjs && node tests/webhook-html-node18-compatibility.mjs && node tests/image-alignment-action.mjs && node tests/resizable-lifecycle.mjs && node tests/table-of-contents-content-switch.mjs && node tests/table-of-contents-visual-lifecycle.mjs"
     },
     "keywords": [],
     "author": "Rico Trevisan",

--- a/lib/tests/resizable-lifecycle.mjs
+++ b/lib/tests/resizable-lifecycle.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Window } from "happy-dom";
+
+const libRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const window = new Window({ url: "https://example.test" });
+
+Object.assign(globalThis, {
+    window,
+    document: window.document,
+    Node: window.Node,
+    HTMLElement: window.HTMLElement,
+    ShadowRoot: window.ShadowRoot,
+    MutationObserver: window.MutationObserver,
+    DOMParser: window.DOMParser,
+    getComputedStyle: window.getComputedStyle.bind(window),
+    requestAnimationFrame: (callback) => setTimeout(() => callback(Date.now()), 0),
+    cancelAnimationFrame: (handle) => clearTimeout(handle),
+});
+Object.defineProperty(globalThis, "navigator", { value: window.navigator, configurable: true });
+
+await import(pathToFileURL(resolve(libRoot, "dist.js")));
+
+const { Editor, Document, Paragraph, Text, Image, Resizable } = window.tiptap;
+const settle = () => new Promise((resolve) => setTimeout(resolve, 300));
+
+async function makeEditor() {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const editor = new Editor({
+        element,
+        extensions: [Document, Paragraph, Text, Image, Resizable],
+        content: '<img src="https://example.test/image.png" style="width: 100px"><p>After</p>',
+    });
+    await window.happyDOM.whenAsyncComplete();
+    editor.commands.setTextSelection(2);
+    editor.commands.setNodeSelection(0);
+    await settle();
+    return editor;
+}
+
+function mouse(target, type, screenX) {
+    target.dispatchEvent(new window.MouseEvent(type, { bubbles: true, screenX }));
+}
+
+function startDrag(editor) {
+    const image = editor.storage.resizable.resizeElement;
+    Object.defineProperty(image, "clientWidth", {
+        configurable: true,
+        get: () => parseInt(image.style.width) || 100,
+    });
+    mouse(editor.resizeLayer.querySelector(".bottom-right"), "mousedown", 100);
+    return image;
+}
+
+// Track the actual document listeners, including ones whose callbacks merely bail out.
+const listeners = new Map([["mousemove", new Set()], ["mouseup", new Set()]]);
+const add = document.addEventListener.bind(document);
+const remove = document.removeEventListener.bind(document);
+document.addEventListener = (type, handler, options) => {
+    listeners.get(type)?.add(handler);
+    return add(type, handler, options);
+};
+document.removeEventListener = (type, handler, options) => {
+    listeners.get(type)?.delete(handler);
+    return remove(type, handler, options);
+};
+const editor = await makeEditor();
+const baseline = [...listeners.values()].map((handlers) => handlers.size);
+function assertNoDragListeners() {
+    assert.deepEqual([...listeners.values()].map((handlers) => handlers.size), baseline);
+}
+let persistCalls = 0;
+const chain = editor.chain.bind(editor);
+editor.chain = () => { persistCalls++; return chain(); };
+for (let i = 0; i < 5; i++) {
+    startDrag(editor);
+    mouse(document, "mousemove", 120);
+    mouse(document, "mouseup", 120);
+    assertNoDragListeners();
+    assert.equal(persistCalls, i + 1, "each drag must persist exactly once");
+    assert.equal(editor.state.doc.firstChild.attrs.width, `${100 + 20 * (i + 1)}px`);
+    await settle();
+}
+mouse(document, "mouseup", 120);
+assert.equal(persistCalls, 5, "completed drags must ignore later mouseup events");
+
+// Starting again cancels the previous drag; teardown cancels the active one.
+startDrag(editor);
+const image = startDrag(editor);
+mouse(document, "mousemove", 125);
+assert.equal(image.style.width, "225px");
+const layer = editor.resizeLayer;
+const detachedHandle = layer.querySelector(".bottom-right");
+const other = await makeEditor();
+let oldReads = 0;
+let otherReads = 0;
+const oldRect = image.getBoundingClientRect.bind(image);
+image.getBoundingClientRect = () => { oldReads++; return oldRect(); };
+const otherImage = other.storage.resizable.resizeElement;
+const otherRect = otherImage.getBoundingClientRect.bind(otherImage);
+otherImage.getBoundingClientRect = () => { otherReads++; return otherRect(); };
+editor.commands.setMeta("resize-test", 1);
+editor.commands.setMeta("resize-test", 2);
+other.commands.setMeta("resize-test", 1);
+other.commands.setMeta("resize-test", 2);
+assert.ok(oldReads > 0 && otherReads > 0, "each editor needs an independent leading throttle call");
+const previousOldReads = oldReads;
+const previousOtherReads = otherReads;
+const storage = editor.storage.resizable;
+const pendingThrottle = storage.transactionHandler;
+editor.destroy();
+assertNoDragListeners();
+let destroyedCallbackChecks = 0;
+Object.defineProperty(editor, "isDestroyed", {
+    configurable: true,
+    get: () => { destroyedCallbackChecks++; return true; },
+});
+pendingThrottle.flush();
+assert.equal(destroyedCallbackChecks, 0, "teardown must cancel queued work, not just guard its callback");
+mouse(document, "mousemove", 160);
+mouse(document, "mouseup", 160);
+mouse(detachedHandle, "mousedown", 100);
+mouse(document, "mousemove", 200);
+mouse(document, "mouseup", 200);
+await settle();
+assert.equal(oldReads, previousOldReads, "destroyed editor must not measure old DOM");
+assert.equal(image.style.width, "225px", "destroyed drag must not mutate old DOM");
+assert.equal(persistCalls, 5, "destroyed editor must not receive old mouseup callbacks");
+assert.equal(layer.isConnected, false, "destroy removes the resize overlay");
+assert.equal(storage.resizeElement, null);
+assert.equal(storage.resizeNode, null);
+assert.ok(otherReads > previousOtherReads, "destroying one editor preserves another's trailing work");
+startDrag(other);
+mouse(document, "mousemove", 130);
+mouse(document, "mouseup", 130);
+assert.equal(other.state.doc.firstChild.attrs.width, "130px");
+other.destroy();
+console.log("Resizable lifecycle: repeated drags, active teardown, and independent throttles pass");

--- a/lib/vendor/tiptap-extension-resizable.js
+++ b/lib/vendor/tiptap-extension-resizable.js
@@ -31,6 +31,9 @@ export default Extension.create({
     return {
       resizeElement: null,
       resizeNode: null,
+      cancelDrag: null,
+      removeResizeListener: null,
+      transactionHandler: null,
     };
   },
 
@@ -65,13 +68,22 @@ export default Extension.create({
     Object.entries(this.options.layerStyle).forEach(([key, value]) => {
       resizeLayer.style[key] = value;
     });
+    // Each editor owns its throttle so teardown cannot cancel another editor's work.
+    this.storage.transactionHandler = throttle(() => {
+      if (editor.isDestroyed) return;
+      if (resizeLayer.style.display === "block" &&
+          !syncResizeLayer(editor, this.storage, this.options.types)) {
+        resizeLayer.style.display = "none";
+      }
+    }, 240);
+
     // Event handling
-    resizeLayer.addEventListener("mousedown", (e) => {
+    const mousedownHandle = (e) => {
       e.preventDefault();
       const resizeElement = this.storage.resizeElement;
-      const resizeNode = this.storage.resizeNode;
-      if (!resizeElement) return;
+      if (!resizeElement || editor.isDestroyed) return;
       if (/bottom/.test(e.target.className)) {
+        this.storage.cancelDrag?.();
         let startX = e.screenX;
         const dir = e.target.classList.contains("bottom-left") ? -1 : 1;
         const mousemoveHandle = (e) => {
@@ -90,17 +102,29 @@ export default Extension.create({
           resizeLayer.style.height = clientHeight + "px";
           startX = e.screenX;
         };
-        document.addEventListener("mousemove", mousemoveHandle);
-        document.addEventListener("mouseup", () => {
+        const cancelDrag = () => {
           document.removeEventListener("mousemove", mousemoveHandle);
+          document.removeEventListener("mouseup", mouseupHandle);
+          this.storage.cancelDrag = null;
+        };
+        const mouseupHandle = () => {
+          cancelDrag();
+          if (editor.isDestroyed) return;
           // Persist the width via proper ProseMirror transaction
           const finalWidth = resizeElement.style.width;
           if (finalWidth) {
-            editor.chain().updateAttributes('image', { width: finalWidth }).run();
+            editor.chain().updateAttributes("image", { width: finalWidth }).run();
           }
-        });
+        };
+        this.storage.cancelDrag = cancelDrag;
+        document.addEventListener("mousemove", mousemoveHandle);
+        document.addEventListener("mouseup", mouseupHandle);
       }
-    });
+    };
+    resizeLayer.addEventListener("mousedown", mousedownHandle);
+    this.storage.removeResizeListener = () => {
+      resizeLayer.removeEventListener("mousedown", mousedownHandle);
+    };
     // Handlers
     const handlers = ["top-left", "top-right", "bottom-left", "bottom-right"];
     const fragment = document.createDocumentFragment();
@@ -123,19 +147,25 @@ export default Extension.create({
     element.appendChild(resizeLayer);
   },
 
-  onTransaction: throttle(function ({ editor }) {
-    const resizeLayer = editor.resizeLayer;
-    if (resizeLayer && resizeLayer.style.display === "block") {
-      // Attribute transactions can replace the selected image DOM node. Always
-      // resolve it again instead of measuring the stale node kept by storage.
-      if (!syncResizeLayer(editor, this.storage, this.options.types)) {
-        resizeLayer.style.display = "none";
-      }
-    }
-  }, 240),
+  onTransaction() {
+    this.storage.transactionHandler?.();
+  },
+
+  onDestroy() {
+    this.storage.cancelDrag?.();
+    this.storage.transactionHandler?.cancel();
+    this.storage.removeResizeListener?.();
+    this.editor.resizeLayer?.remove();
+    this.editor.resizeLayer = null;
+    this.storage.transactionHandler = null;
+    this.storage.removeResizeListener = null;
+    this.storage.resizeElement = null;
+    this.storage.resizeNode = null;
+  },
 
   onSelectionUpdate: function ({ editor }) {
     const resizeLayer = editor.resizeLayer;
+    if (!resizeLayer || editor.isDestroyed) return;
     if (!syncResizeLayer(editor, this.storage, this.options.types)) {
       resizeLayer.style.display = "none";
       this.storage.resizeElement = null;

--- a/src/elements/tiptap-AAC/headers.html
+++ b/src/elements/tiptap-AAC/headers.html
@@ -1,4 +1,4 @@
-<script src="//meta-q.cdn.bubble.io/f1786967618467x217669016491782940/dist.js" defer></script>
+<script src="//meta-q.cdn.bubble.io/f1788984698987x468409416958701630/dist-issue-25-074b78ae9313.js" defer></script>
 
 <script
     src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -119,6 +119,10 @@
     "AHO": {
       "name": "dist.js",
       "url": "//meta-q.cdn.bubble.io/f1786967618467x217669016491782940/dist.js"
+    },
+    "AHP": {
+      "name": "dist-issue-25-074b78ae9313.js",
+      "url": "//meta-q.cdn.bubble.io/f1788984698987x468409416958701630/dist-issue-25-074b78ae9313.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Clean up resize listeners and overlays when an editor is destroyed.
- Prevent stale drag callbacks and DOM updates after teardown.
- Isolate throttled transaction handlers per editor instance.
- Add lifecycle coverage and publish the rebuilt bundle.

## Testing

- `cd lib && npm ci && npm test`
- Added repeated-drag, teardown, listener cleanup, and independent-throttle lifecycle checks.